### PR TITLE
Issue15

### DIFF
--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -628,6 +628,26 @@ class LayeredGroupBase:
         self.assertEqual(len(self.LG._spritelist), 1)
         self.assertEqual(layer, expected_layer)
 
+    def test_add_bad_class_sprite(self):
+        expected_layer = 100
+        spr = BadSpriteInstance()
+        
+        try:
+            # Should not be able to add bad sprite
+            self.LG.add(spr, layer=expected_layer)
+        except (TypeError, AttributeError):
+            checker0 = True
+        
+        try:
+            # Should not add the attribute _spritelayers to bad sprite
+            self.assertEqual(self._spritelayers, 1)
+        except AttributeError:
+            checker1 = True
+
+        self.assertTrue(checker0)
+        self.assertTrue(checker1)
+
+
     def test_add__overriding_sprite_layer_attr(self):
         expected_layer = 200
         spr = self.sprite()
@@ -1100,6 +1120,9 @@ class DirtySpriteTypeTest(SpriteBase, unittest.TestCase):
                sprite.OrderedUpdates,
                sprite.LayeredDirty, ]
 
+class BadSpriteInstance():
+    pass
+
 ############################## BUG TESTS #######################################
 
 class SingleGroupBugsTest(unittest.TestCase):
@@ -1135,6 +1158,5 @@ class SingleGroupBugsTest(unittest.TestCase):
 
 
 ################################################################################
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -636,17 +636,11 @@ class LayeredGroupBase:
             # Should not be able to add bad sprite
             self.LG.add(spr, layer=expected_layer)
         except (TypeError, AttributeError):
-            checker0 = True
+            checker = True
         
-        try:
-            # Should not add the attribute _spritelayers to bad sprite
-            self.assertEqual(self._spritelayers, 1)
-        except AttributeError:
-            checker1 = True
-
-        self.assertTrue(checker0)
-        self.assertTrue(checker1)
-
+        self.assertTrue(checker)
+        # Sprite should not have been added to the layer
+        self.assertFalse(hasattr(self, '_spritelayers'))
 
     def test_add__overriding_sprite_layer_attr(self):
         expected_layer = 200


### PR DESCRIPTION
Adding coverage for lines 714-726 by entering the exception clause in the add() function. This is done by sending a sprite to add() that is an instance of a bad class that does nothing (i.e. not the correct Sprite class). This results in that it now only lacks coverage for 720-723, I couldn't think of a way to test those lines.