### PR TITLE
issue #16 [fix] extend sprite test "test_has" to enter exception clause

### DIFF
--- a/test/sprite_test.py
+++ b/test/sprite_test.py
@@ -487,6 +487,10 @@ class AbstractGroupTypeTest( unittest.TestCase ):
         # see if a second AbstractGroup works.
         self.assertEqual(True, self.ag2.has(self.s3))
 
+        # test exception clause for bad sprite class
+        spr = BadSpriteInstance()
+        self.assertFalse(self.ag.has(spr))
+
     def test_add(self):
         ag3 = sprite.AbstractGroup()
         sprites = (self.s1, self.s2, self.s3, self.s4)
@@ -1099,6 +1103,9 @@ class DirtySpriteTypeTest(SpriteBase, unittest.TestCase):
                sprite.RenderUpdates,
                sprite.OrderedUpdates,
                sprite.LayeredDirty, ]
+    
+class BadSpriteInstance():
+    pass
 
 ############################## BUG TESTS #######################################
 


### PR DESCRIPTION
Sending a sprite of a bad class to has() and making sure it enters the exception clause and returns false (because the sprite doesn't exist in the group).

This increases coverage with 1 % for that function. The CC of has() is 10.